### PR TITLE
 Allow passing reference object to hook.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for use-resize-observer
 // Project: use-resize-observer
 
-import { RefObject } from 'react';
+import { RefObject, MutableRefObject } from 'react';
 
-export default function useResizeObserver(): [RefObject<HTMLElement>, number, number];
-
+function useResizeObserver(): [RefObject<HTMLElement>, number, number];
+function useResizeObserver(ref: MutableRefObject<HTMLElement>): [number, number, RefObject<HTMLElement>];
+export default useResizeObserver;

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,42 @@
 import { useEffect, useState, useRef } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
-export default function() {
-  const ref = useRef();
+export default function(ref) {
+  const defaultRef = useRef();
+  ref = ref || defaultRef;
+  const [observer, setObserver] = useState(null);
   const [width, changeWidth] = useState(1);
   const [height, changeHeight] = useState(1);
-
+  
   useEffect(() => {
-    const element = ref.current;
     const resizeObserver = new ResizeObserver(entries => {
-      if (!Array.isArray(entries)) {
-        return;
-      }
-
       // Since we only observe the one element, we don't need to loop over the
       // array
-      if (!entries.length) {
+      if (!Array.isArray(entries) || !entries.length) {
         return;
       }
-
       const entry = entries[0];
-
       changeWidth(entry.contentRect.width);
       changeHeight(entry.contentRect.height);
     });
-
-    resizeObserver.observe(element);
-
-    return () => resizeObserver.unobserve(element);
+    setObserver(resizeObserver);
+    return () => resizeObserver.disconnect();
   }, []);
 
-  return [ref, width, height];
+  useEffect(() => {
+    const element = ref.current;
+    if (!observer || !element) {
+      return;
+    }
+    observer.observe(element);
+    return () => observer.unobserve(element);
+  }, [observer, ref]);
+
+  // Since ref can be passed to function manually. It must be optional output.
+  // Save compatibility with v3.1.0 and earlier.
+  if (defaultRef === ref) {
+    return [ref, width, height];
+  } else {
+    return [width, height, ref];
+  }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -25,14 +25,14 @@ const Observed = () => {
   const [width2, height2] = useResizeObserver(ref2);
 
   return (
-    <>
+    <div>
       <div ref={ref1} id="observed1" style={styles}>
         1 {width1}x{height1}
       </div>
       <div ref={ref2} id="observed2" style={styles}>
         2 {width2}x{height2}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import ReactDOM from "react-dom";
 import useResizeObserver from "../dist/bundle.esm";
 import delay from "delay";
@@ -9,25 +9,30 @@ import delay from "delay";
 import "babel-regenerator-runtime";
 
 const Observed = () => {
-  const [ref, width, height] = useResizeObserver();
+  const [ref1, width1, height1] = useResizeObserver();
+  const styles = {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: "100%",
+    height: "100%",
+    background: "grey",
+    color: "white",
+    fontWeight: "bold"
+  };
+
+  const ref2 = useRef();
+  const [width2, height2] = useResizeObserver(ref2);
 
   return (
-    <div
-      ref={ref}
-      id="observed"
-      style={{
-        position: "absolute",
-        left: 0,
-        top: 0,
-        width: "100%",
-        height: "100%",
-        background: "grey",
-        color: "white",
-        fontWeight: "bold"
-      }}
-    >
-      {width}x{height}
-    </div>
+    <>
+      <div ref={ref1} id="observed1" style={styles}>
+        1 {width1}x{height1}
+      </div>
+      <div ref={ref2} id="observed2" style={styles}>
+        2 {width2}x{height2}
+      </div>
+    </>
   );
 };
 
@@ -41,17 +46,19 @@ beforeAll(() => {
   ReactDOM.render(<Observed />, app);
 
   global.app = app;
-  global.observed = document.querySelector("#observed");
+  global.observed1 = document.querySelector("#observed1");
+  global.observed2 = document.querySelector("#observed2");
 });
 
-it("should render with 1x1 initially, before the ResizeObserver is triggered", async () => {
-  expect(observed.textContent).toBe("1x1");
+it("hould render with 1x1 initially, before the ResizeObserver is triggered", async () => {
+  expect(observed1.textContent).toBe("1 1x1");
+  expect(observed2.textContent).toBe("2 1x1");
 });
 
 it("should report the correct size after the size is reported by the ResizeObserver", async () => {
   await delay(100);
-
-  expect(observed.textContent).toBe("200x300");
+  expect(observed1.textContent).toBe("1 200x300");
+  expect(observed2.textContent).toBe("2 200x300");
 });
 
 it("should report following size changes", async () => {
@@ -59,5 +66,6 @@ it("should report following size changes", async () => {
   app.style.height = "100px";
 
   await delay(100);
-  expect(observed.textContent).toBe("100x100");
+  expect(observed1.textContent).toBe("1 100x100");
+  expect(observed2.textContent).toBe("2 100x100");
 });


### PR DESCRIPTION
It is essential in cases, when ref must be created in some other place, than this hook. Updated [example of usage](https://codesandbox.io/s/useresizeobserver-react-hook-9t1g8?fontsize=14).