### PR TITLE
useResizeObserver ref type aligned with useRef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for use-resize-observer
 // Project: use-resize-observer
 
-import { RefObject } from 'react';
+import { MutableRefObject } from 'react';
 
-export default function useResizeObserver(): [RefObject<HTMLElement>, number, number];
-
+export default function useResizeObserver(): [MutableRefObject<any>, number, number];


### PR DESCRIPTION
MutableRefObject<any> is what useRef returns. With this change, the refs are interchangeable.
This also allows it to be placed on more elements without TypeScript complaining. Solves #12 