### PR TITLE
Do not save the library as devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A React hook that allows you to use a ResizeObserver to measure an element's siz
 ## Install
 
 ```sh
-yarn add use-resize-observer --dev
+yarn add use-resize-observer
 # or
-npm install use-resize-observer --save-dev
+npm install use-resize-observer --save
 ```
 
 ## Basic Usage


### PR DESCRIPTION
This will be shipped in production for most use cases, the Docs indicates to save as a `devDependency`