### PR TITLE
Added guard against HTMLElement in callSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Misc
+
+- Added guard against undefined `HTMLElement` in `callSubscriber` for SSR
+
 # [7.0.0](https://github.com/ZeeCoder/use-resize-observer/compare/v6.1.0...v7.0.0) (2020-11-11)
 
 ### Bug Fixes

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ function useResolvedElement<T extends HTMLElement>(
       element = callbackRefElement.current;
     } else if (refElement.current) {
       element = refElement.current;
-    } else if (refOrElement instanceof HTMLElement) {
+    } else if (typeof HTMLElement !== "undefined" && refOrElement instanceof HTMLElement) {
       element = refOrElement;
     }
 
@@ -59,7 +59,7 @@ function useResolvedElement<T extends HTMLElement>(
     }
   };
 
-  if (refOrElement && !(refOrElement instanceof HTMLElement)) {
+  if (refOrElement && typeof HTMLElement !== "undefined" && !(refOrElement instanceof HTMLElement)) {
     // Overriding the default ref with the given one
     ref = refOrElement;
   }


### PR DESCRIPTION
Hi!

Thank you for the library! We are using v7.0.0 in one of the Next.js projects recently.

In one of the few instances that we are using this library, we are providing a 
```js
export default function AComponent(): JSX.Element {
  const ref = useRef<HTMLDivElement>(null);
  useResizeObserver<HTMLDivElement>({
    ref,
    onResize: ({ width }) => {
      // Do something here
    },
  });
  return (
    <div ref={ref}>{/* snip */}</div>
  );
}
```

However when we try to build it with `next build`, there will be a `ReferenceError: HTMLElement is not defined`.

```
ReferenceError: HTMLElement is not defined
    at useResolvedElement (node_modules/use-resize-observer/dist/bundle.cjs.js:54:23)
    at useResizeObserver (node_modules/use-resize-observer/dist/bundle.cjs.js:113:21)
```
 
...which I believe is caused by the `HTMLElement` being referenced in the server-side, when it is trying to resolve the element.

Admittedly I am not sure if we are actually abusing/misusing the library, or if the patch is merely hiding some bugs/issues lying deeper within the logic, since in another component that uses the `ref` from the library (just like what README says):
```js
export default function BComponent(): JSX.Element {
  const { ref } = useResizeObserver<HTMLDivElement>({
    onResize: ({ width }) => {
      // Do something here
    },
  });
  return (
    <div ref={ref}>{/* snip */}</div>
  );
}
```
...does not result in such error.

What do you think?