### PR TITLE
allow the usage of a custom resize observer class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ function useResizeObserver<T extends HTMLElement>(
   opts: {
     ref?: RefObject<T> | T | null | undefined;
     onResize?: ResizeHandler;
-    customResizeObserver?: ResizeObserver;
+    customResizeObserver?: typeof ResizeObserver;
   } = {}
 ): HookResponse<T> {
   // Saving the callback as a ref. With this, I don't need to put onResize in the
@@ -179,7 +179,7 @@ function useResizeObserver<T extends HTMLElement>(
       });
     }
 
-    resizeObserverRef.current.observe(element);
+    resizeObserverRef.current!.observe(element);
 
     return () => {
       if (resizeObserverRef.current) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ function useResizeObserver<T extends HTMLElement>(
   opts: {
     ref?: RefObject<T> | T | null | undefined;
     onResize?: ResizeHandler;
+    customResizeObserver?: ResizeObserver;
   } = {}
 ): HookResponse<T> {
   // Saving the callback as a ref. With this, I don't need to put onResize in the
@@ -143,7 +144,8 @@ function useResizeObserver<T extends HTMLElement>(
     // Initialising the RO instance
     if (!resizeObserverRef.current) {
       // Saving a single instance, used by the hook from this point on.
-      resizeObserverRef.current = new ResizeObserver((entries) => {
+      const ResizeObserverClass = opts.customResizeObserver || ResizeObserver;
+      resizeObserverRef.current = new ResizeObserverClass((entries) => {
         if (!Array.isArray(entries)) {
           return;
         }


### PR DESCRIPTION
I'd like to inject a polyfill when window.ResizeObserver is not available. By adding a customResizeObserver optional option I could do:

```
{
  ...
  customResizeObserver: window.ResizeObserver || resizeObserverPolyfill
}
```

This PR does that.