### PR TITLE
Added host to hooks for instanceof check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,16 +38,19 @@ export type RoundingFunction = (n: number) => number;
 
 function useResizeObserver<T extends Element>(
   opts: {
+    host: Window & typeof globalThis,
     ref?: RefObject<T> | T | null | undefined;
     onResize?: ResizeHandler;
     box?: ResizeObserverBoxOptions;
     round?: RoundingFunction;
-  } = {}
+  } = {
+    host: window
+  }
 ): HookResponse<T> {
   // Saving the callback as a ref. With this, I don't need to put onResize in the
   // effect dep array, and just passing in an anonymous function without memoising
   // will not reinstantiate the hook's ResizeObserver.
-  const onResize = opts.onResize;
+  const { onResize, host } = opts;
   const onResizeRef = useRef<ResizeHandler | undefined>(undefined);
   onResizeRef.current = onResize;
   const round = opts.round || Math.round;
@@ -152,6 +155,7 @@ function useResizeObserver<T extends Element>(
       },
       [opts.box, round]
     ),
+    host,
     opts.ref
   );
 

--- a/src/utils/useResolvedElement.ts
+++ b/src/utils/useResolvedElement.ts
@@ -7,7 +7,8 @@ type SubscriberResponse = SubscriberCleanupFunction | void;
 // refs to such extent, but then composing hooks and components could not opt out of unnecessary renders.
 export default function useResolvedElement<T extends Element>(
   subscriber: (element: T) => SubscriberResponse,
-  refOrElement?: T | RefObject<T> | null
+  host: Window & typeof globalThis = window,
+  refOrElement?: T | RefObject<T> | null,
 ): RefCallback<T> {
   const lastReportRef = useRef<{
     element: T | null;
@@ -31,7 +32,7 @@ export default function useResolvedElement<T extends Element>(
     const element: T | null = cbElement
       ? cbElement
       : refOrElement
-      ? refOrElement instanceof Element
+      ? refOrElement instanceof host.Element
         ? refOrElement
         : refOrElement.current
       : null;


### PR DESCRIPTION
Hi @ZeeCoder , thanks for creating this library. We are using this package, and we'd like to help make it better. Our use case includes passing in child window's window object. `instanceof` checks the prototype, and that's unique on each window. So to make sure `instanceof` works reliably, we need to pass in the host object and compare to the correct `Element`. Default case is the global `window` object. 

Hope you could give this PR a look when you are free. Thank you!