### PR TITLE
Do not report undefined size instead of 0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,8 +118,8 @@ function useResizeObserver<T extends Element>(
               const reportedWidth = extractSize(entry, boxProp, "inlineSize");
               const reportedHeight = extractSize(entry, boxProp, "blockSize");
 
-              const newWidth = reportedWidth ? round(reportedWidth) : undefined;
-              const newHeight = reportedHeight
+              const newWidth = reportedWidth != null ? round(reportedWidth) : undefined;
+              const newHeight = reportedHeight != null
                 ? round(reportedHeight)
                 : undefined;
 


### PR DESCRIPTION
With the current code, there is no way to differentiate a still unknown size from a 0 size